### PR TITLE
feature: enable recommended virtual dom lint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@ import * as actions from '@lvce-editor/eslint-plugin-github-actions'
 
 export default [
   ...config.default,
+  ...config.recommendedVirtualDom,
   ...actions.default,
 
   {
@@ -54,6 +55,12 @@ export default [
       'sonarjs/assertions-in-tests': 'off',
       'sonarjs/no-redundant-jump': 'off',
       'sonarjs/prefer-specific-assertions': 'off',
+      'virtual-dom/no-inline-event-handlers': 'off',
+      'virtual-dom/no-inline-style': 'off',
+      'virtual-dom/no-object-attribute-values': 'off',
+      'virtual-dom/prefer-constants': 'off',
+      'virtual-dom/prefer-merge-class-names': 'off',
+      'virtual-dom/prefer-state-destructuring': 'off',
     },
   },
   {
@@ -66,6 +73,18 @@ export default [
   {
     rules: {
       '@cspell/spellchecker': 'off',
+    },
+  },
+  {
+    files: ['packages/debug-worker/src/parts/RenderDebugValue/RenderDebugValue.ts'],
+    rules: {
+      'virtual-dom/no-object-attribute-values': 'off',
+    },
+  },
+  {
+    files: ['packages/debug-worker/src/parts/RenderMissingDebugProvider/RenderMissingDebugProvider.ts'],
+    rules: {
+      'virtual-dom/no-inline-style': 'off',
     },
   },
 ]

--- a/packages/debug-worker/src/parts/GetArrowNodes/GetArrowNodes.ts
+++ b/packages/debug-worker/src/parts/GetArrowNodes/GetArrowNodes.ts
@@ -1,5 +1,6 @@
 import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
+import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 
 export const getArrowNodes = (hasArrow: boolean | undefined): readonly VirtualDomNode[] => {
@@ -15,7 +16,7 @@ export const getArrowNodes = (hasArrow: boolean | undefined): readonly VirtualDo
     },
     {
       childCount: 0,
-      className: 'MaskIcon MaskIconArrowRight',
+      className: MergeClassNames.mergeClassNames('MaskIcon', 'MaskIconArrowRight'),
       type: VirtualDomElements.Div,
     },
   ]

--- a/packages/debug-worker/src/parts/GetChevronVirtualDom/GetChevronVirtualDom.ts
+++ b/packages/debug-worker/src/parts/GetChevronVirtualDom/GetChevronVirtualDom.ts
@@ -1,11 +1,12 @@
 import type { VirtualDomNode } from '@lvce-editor/virtual-dom-worker'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
+import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 
 export const getChevronDownVirtualDom = (extraClassName = ''): VirtualDomNode => {
   return {
     childCount: 0,
-    className: `${ClassNames.Chevron} MaskIconChevronDown ${extraClassName}`,
+    className: MergeClassNames.mergeClassNames(ClassNames.Chevron, 'MaskIconChevronDown', extraClassName),
     type: VirtualDomElements.Div,
   }
 }
@@ -13,7 +14,7 @@ export const getChevronDownVirtualDom = (extraClassName = ''): VirtualDomNode =>
 export const getChevronRightVirtualDom = (extraClassName = ''): VirtualDomNode => {
   return {
     childCount: 0,
-    className: `${ClassNames.Chevron} MaskIconChevronRight ${extraClassName}`,
+    className: MergeClassNames.mergeClassNames(ClassNames.Chevron, 'MaskIconChevronRight', extraClassName),
     type: VirtualDomElements.Div,
   }
 }

--- a/packages/debug-worker/src/parts/GetDebugButtonVirtualDom/GetDebugButtonVirtualDom.ts
+++ b/packages/debug-worker/src/parts/GetDebugButtonVirtualDom/GetDebugButtonVirtualDom.ts
@@ -4,7 +4,7 @@ import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 
-const DebugButtonClass = ClassNames.IconButton + ' ' + ClassNames.DebugButton
+const DebugButtonClass = MergeClassNames.mergeClassNames(ClassNames.IconButton, ClassNames.DebugButton)
 
 export const getDebugButtonVirtualDom = (button: DebugButton): readonly VirtualDomNode[] => {
   const { fn, icon, title } = button
@@ -18,7 +18,7 @@ export const getDebugButtonVirtualDom = (button: DebugButton): readonly VirtualD
     },
     {
       childCount: 0,
-      className: `MaskIcon MaskIcon${icon}`,
+      className: MergeClassNames.mergeClassNames('MaskIcon', `MaskIcon${icon}`),
       type: VirtualDomElements.Div,
     },
   ]

--- a/packages/debug-worker/src/parts/GetRunAndDebugVirtualDom2/GetRunAndDebugVirtualDom2.ts
+++ b/packages/debug-worker/src/parts/GetRunAndDebugVirtualDom2/GetRunAndDebugVirtualDom2.ts
@@ -2,15 +2,17 @@ import type { DebugRow } from '../DebugRow/DebugRow.ts'
 import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
 import * as AriaRoles from '../AriaRoles/AriaRoles.ts'
 import * as GetRunAndDebugRowVirtualDom from '../GetRunAndDebugRowVirtualDom/GetRunAndDebugRowVirtualDom.ts'
+import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
+import * as TabIndex from '../TabIndex/TabIndex.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 
 export const getRunAndDebugVirtualDom2 = (rows: readonly DebugRow[], selectedIndex: number, tokenColoringEnabled: boolean): readonly VirtualDomNode[] => {
   return [
     {
       childCount: rows.length,
-      className: 'Viewlet RunAndDebug',
+      className: MergeClassNames.mergeClassNames('Viewlet', 'RunAndDebug'),
       role: AriaRoles.Tree,
-      tabIndex: 0,
+      tabIndex: TabIndex.Focusable,
       type: VirtualDomElements.Div,
     },
     ...rows.flatMap((row, index) => GetRunAndDebugRowVirtualDom.getRunAndDebugRowVirtualDom(row, selectedIndex, index, tokenColoringEnabled)),

--- a/packages/debug-worker/src/parts/GetRunAndDebugVisibleRows/GetRunAndDebugVisibleRows.ts
+++ b/packages/debug-worker/src/parts/GetRunAndDebugVisibleRows/GetRunAndDebugVisibleRows.ts
@@ -9,7 +9,8 @@ import { getRunAndDebugVisibleRowsScope } from '../GetRunAndDebugVisibleRowsScop
 import { getRunAndDebugVisibleRowsWatch } from '../GetRunAndDebugVisibleRowsWatch/GetRunAndDebugVisibleRowsWatch.ts'
 
 export const getRunAndDebugVisibleRows = (state: RunAndDebugState): readonly DebugRow[] => {
-  if (state.debugState === DebugState.Unavailable) {
+  const { debugProviderMessage, debugState, topLevelCount } = state
+  if (debugState === DebugState.Unavailable) {
     return [
       {
         description: '',
@@ -28,7 +29,7 @@ export const getRunAndDebugVisibleRows = (state: RunAndDebugState): readonly Deb
     ]
   }
 
-  if (state.debugState === DebugState.MissingProvider) {
+  if (debugState === DebugState.MissingProvider) {
     return [
       {
         description: '',
@@ -39,7 +40,7 @@ export const getRunAndDebugVisibleRows = (state: RunAndDebugState): readonly Deb
         name: '',
         posInset: 1,
         setSize: 1,
-        text: state.debugProviderMessage,
+        text: debugProviderMessage,
         type: DebugRowType.MissingDebugProvider,
         value: '',
         valueType: '',
@@ -47,7 +48,6 @@ export const getRunAndDebugVisibleRows = (state: RunAndDebugState): readonly Deb
     ]
   }
 
-  const { topLevelCount } = state
   const watchRows = getRunAndDebugVisibleRowsWatch(state, 0, topLevelCount, 0)
   const breakPointsRows = getRunAndDebugVisibleRowsBreakPoints(state, watchRows.length, topLevelCount, 1)
   const scopeRows = getRunAndDebugVisibleRowsScope(state, watchRows.length + breakPointsRows.length, topLevelCount, 2)

--- a/packages/debug-worker/src/parts/HandlePaused2/HandlePaused2.ts
+++ b/packages/debug-worker/src/parts/HandlePaused2/HandlePaused2.ts
@@ -5,9 +5,9 @@ import { getPausedInfo2 } from '../GetPausedInfo2/GetPausedInfo2.ts'
 import { updateVisibleRows } from '../UpdateVisibleRows/UpdateVisibleRows.ts'
 
 export const handlePaused2 = async (state: RunAndDebugState): Promise<RunAndDebugState> => {
-  const { debugId, watchExpressions } = state
+  const { debugId, maxDescriptionLength, watchExpressions } = state
   try {
-    const { callFrameId, callStack, expandedIds, pausedMessage, pausedReason, scopeChain, scriptMap } = await getPausedInfo2(debugId, state.maxDescriptionLength)
+    const { callFrameId, callStack, expandedIds, pausedMessage, pausedReason, scopeChain, scriptMap } = await getPausedInfo2(debugId, maxDescriptionLength)
     // TODO move this to getPausedInfo2
     const newWatchExpressions = await evaluateWatchExpressions(debugId, callFrameId, watchExpressions)
     const newState = {

--- a/packages/debug-worker/src/parts/HandleRename/HandleRename.ts
+++ b/packages/debug-worker/src/parts/HandleRename/HandleRename.ts
@@ -4,13 +4,13 @@ import { editWatchExpression } from '../EditWatchExpression/EditWatchExpression.
 import { getRunAndDebugVisibleRows } from '../GetRunAndDebugVisibleRows/GetRunAndDebugVisibleRows.ts'
 
 export const handleRename = async (state: RunAndDebugState): Promise<RunAndDebugState> => {
-  const { selectedIndex } = state
+  const { selectedIndex, watchExpressions } = state
   const rows = getRunAndDebugVisibleRows(state)
   const row = rows[selectedIndex]
 
   if (row && row.type === DebugRowType.WatchExpression && row.index !== undefined) {
     const watchIndex = row.index
-    const watchExpression = state.watchExpressions[watchIndex]
+    const watchExpression = watchExpressions[watchIndex]
 
     if (watchExpression && !watchExpression.isEditing) {
       return editWatchExpression(state, watchIndex)

--- a/packages/debug-worker/src/parts/HandleWatchExpressionContextMenu/HandleWatchExpressionContextMenu.ts
+++ b/packages/debug-worker/src/parts/HandleWatchExpressionContextMenu/HandleWatchExpressionContextMenu.ts
@@ -5,13 +5,14 @@ import { parseIndex } from '../ParseIndex/ParseIndex.ts'
 import * as RunAndDebugStates from '../RunAndDebugStates/RunAndDebugStates.ts'
 
 export const handleWatchExpressionContextMenu = async (state: RunAndDebugState, x: number, y: number, dataIndex: string): Promise<RunAndDebugState> => {
+  const { uid } = state
   const index = parseIndex(dataIndex)
   const newState: RunAndDebugState = {
     ...state,
     focusedIndex: index,
   }
-  const { oldState } = RunAndDebugStates.get(state.uid)
-  RunAndDebugStates.set(state.uid, oldState, newState)
+  const { oldState } = RunAndDebugStates.get(uid)
+  RunAndDebugStates.set(uid, oldState, newState)
   await ContextMenu.show(x, y, MenuEntryId.DebugWatchExpression)
   return state
 }

--- a/packages/debug-worker/src/parts/RenderDebugValue/RenderDebugValue.ts
+++ b/packages/debug-worker/src/parts/RenderDebugValue/RenderDebugValue.ts
@@ -23,7 +23,7 @@ export const renderValue = (row: DebugRow, selectedIndex: number, rowIndex: numb
       valueChildren.push({
         childCount: 1,
         children: [VirtualDomHelpers.text(tokens[i])],
-        className: `DebugToken DebugToken${tokens[i + 1]}`,
+        className: MergeClassNames.mergeClassNames(ClassNames.DebugToken, `DebugToken${tokens[i + 1]}`),
         type: VirtualDomElements.Span,
       })
     }
@@ -45,7 +45,7 @@ export const renderValue = (row: DebugRow, selectedIndex: number, rowIndex: numb
     },
     {
       childCount: 1,
-      className: 'DebugValue DebugPropertyKey',
+      className: MergeClassNames.mergeClassNames(ClassNames.DebugValue, ClassNames.DebugPropertyKey),
       type: VirtualDomElements.Span,
     },
     VirtualDomHelpers.text(key),

--- a/packages/debug-worker/src/parts/RenderMissingDebugProvider/RenderMissingDebugProvider.ts
+++ b/packages/debug-worker/src/parts/RenderMissingDebugProvider/RenderMissingDebugProvider.ts
@@ -2,6 +2,7 @@ import type { DebugRow } from '../DebugRow/DebugRow.ts'
 import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
 import * as DebugStrings from '../DebugStrings/DebugStrings.ts'
 import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEventListenerFunctions.ts'
+import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 import * as VirtualDomHelpers from '../VirtualDomHelpers/VirtualDomHelpers.ts'
 
@@ -22,7 +23,7 @@ export const renderMissingDebugProvider = (row: DebugRow): readonly VirtualDomNo
     VirtualDomHelpers.text(row.text),
     {
       childCount: 1,
-      className: 'Button ButtonSecondary MissingDebugProviderButton',
+      className: MergeClassNames.mergeClassNames('Button', 'ButtonSecondary', 'MissingDebugProviderButton'),
       onClick: DomEventListenerFunctions.HandleClickOpenExtensions,
       title: DebugStrings.openExtensions(),
       type: VirtualDomElements.Button,

--- a/packages/debug-worker/src/parts/SelectNextRow/SelectNextRow.ts
+++ b/packages/debug-worker/src/parts/SelectNextRow/SelectNextRow.ts
@@ -2,5 +2,6 @@ import type { RunAndDebugState } from '../RunAndDebugState/RunAndDebugState.ts'
 import { selectIndex } from '../SelectIndex/SelectIndex.ts'
 
 export const selectNextRow = (state: RunAndDebugState): RunAndDebugState => {
-  return selectIndex(state, state.selectedIndex + 1)
+  const { selectedIndex } = state
+  return selectIndex(state, selectedIndex + 1)
 }

--- a/packages/debug-worker/src/parts/SelectPreviousRow/SelectPreviousRow.ts
+++ b/packages/debug-worker/src/parts/SelectPreviousRow/SelectPreviousRow.ts
@@ -2,8 +2,9 @@ import type { RunAndDebugState } from '../RunAndDebugState/RunAndDebugState.ts'
 import { selectIndex } from '../SelectIndex/SelectIndex.ts'
 
 export const selectPreviousRow = (state: RunAndDebugState): RunAndDebugState => {
-  if (state.selectedIndex === 0) {
+  const { selectedIndex } = state
+  if (selectedIndex === 0) {
     return state
   }
-  return selectIndex(state, state.selectedIndex - 1)
+  return selectIndex(state, selectedIndex - 1)
 }

--- a/packages/debug-worker/src/parts/TabIndex/TabIndex.ts
+++ b/packages/debug-worker/src/parts/TabIndex/TabIndex.ts
@@ -1,0 +1,1 @@
+export const Focusable = 0

--- a/packages/debug-worker/test/GetChevronVirtualDom.test.ts
+++ b/packages/debug-worker/test/GetChevronVirtualDom.test.ts
@@ -6,7 +6,7 @@ test('getChevronDownVirtualDom', () => {
   const result = GetChevronVirtualDom.getChevronDownVirtualDom()
   expect(result).toEqual({
     childCount: 0,
-    className: 'Chevron MaskIconChevronDown ',
+    className: 'Chevron MaskIconChevronDown',
     type: VirtualDomElements.Div,
   })
 })
@@ -24,7 +24,7 @@ test('getChevronRightVirtualDom', () => {
   const result = GetChevronVirtualDom.getChevronRightVirtualDom()
   expect(result).toEqual({
     childCount: 0,
-    className: 'Chevron MaskIconChevronRight ',
+    className: 'Chevron MaskIconChevronRight',
     type: VirtualDomElements.Div,
   })
 })


### PR DESCRIPTION
Enable the shared `recommendedVirtualDom` ESLint preset and fix production findings.

- merge composed class names and remove trailing class whitespace
- replace the raw focus tab index with a named constant
- destructure state access identified by the preset
- scope nested token-node, inline-style, and fixture exceptions narrowly
- keep lint, type-checking, and 490 active tests green