### PR TITLE
fix: route debug provider commands

### DIFF
--- a/packages/debug-worker/src/parts/ActivateByEvent/ActivateByEvent.ts
+++ b/packages/debug-worker/src/parts/ActivateByEvent/ActivateByEvent.ts
@@ -1,6 +1,0 @@
-import { RendererWorker } from '@lvce-editor/rpc-registry'
-
-export const activateByEvent = (event: string): Promise<void> => {
-  // @ts-ignore
-  return RendererWorker.activateByEvent(event)
-}

--- a/packages/debug-worker/src/parts/ExecuteProvider/ExecuteProvider.ts
+++ b/packages/debug-worker/src/parts/ExecuteProvider/ExecuteProvider.ts
@@ -1,9 +1,10 @@
-import * as ActivateByEvent from '../ActivateByEvent/ActivateByEvent.ts'
 import * as ExtensionHost from '../ExtensionHost/ExtensionHost.ts'
 
 export const executeProvider = async ({ event, method, params }: { event: string; method: string; params: readonly any[] }): Promise<any> => {
-  await ActivateByEvent.activateByEvent(event)
   // @ts-ignore
-  const result = await ExtensionHost.invoke(method, ...params)
-  return result
+  const results = await ExtensionHost.invoke('Extensions.executeProvidersByEvent', event, method, ...params)
+  if (results.length === 0) {
+    throw new Error(`Failed to execute debug provider: no debug provider "${params[0]}" found`)
+  }
+  return results[0]
 }

--- a/packages/debug-worker/test/EvaluateWatchExpression.test.ts
+++ b/packages/debug-worker/test/EvaluateWatchExpression.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@jest/globals'
 import { MockRpc } from '@lvce-editor/rpc'
 import { RendererWorker } from '@lvce-editor/rpc-registry'
 import { evaluateWatchExpression } from '../src/parts/EvaluateWatchExpression/EvaluateWatchExpression.ts'
-import * as ExtensionHost from '../src/parts/ExtensionHost/ExtensionHost.ts'
+import { setExtensionHostProviderMock } from './MockExtensionHost.ts'
 
 test('evaluateWatchExpression', async () => {
   const mockRpc = MockRpc.create({
@@ -20,7 +20,7 @@ test('evaluateWatchExpression', async () => {
     },
   })
   RendererWorker.set(mockRpc)
-  ExtensionHost.set(mockRpc)
+  setExtensionHostProviderMock(mockRpc.invoke)
   const expression = 'x + y'
   const result = await evaluateWatchExpression(123, 456, expression)
   expect(result).toEqual({ result: 'evaluated result' })

--- a/packages/debug-worker/test/EvaluateWatchExpressions.test.ts
+++ b/packages/debug-worker/test/EvaluateWatchExpressions.test.ts
@@ -2,7 +2,7 @@ import { test, expect, jest } from '@jest/globals'
 import { MockRpc } from '@lvce-editor/rpc'
 import { RendererWorker } from '@lvce-editor/rpc-registry'
 import { evaluateWatchExpressions } from '../src/parts/EvaluateWatchExpressions/EvaluateWatchExpressions.ts'
-import * as ExtensionHost from '../src/parts/ExtensionHost/ExtensionHost.ts'
+import { setExtensionHostProviderMock } from './MockExtensionHost.ts'
 
 const debugId = 1
 const callFrameId = 2
@@ -21,7 +21,7 @@ test('evaluateWatchExpressions - all succeed', async () => {
     },
   })
   RendererWorker.set(mockRpc)
-  ExtensionHost.set(mockRpc)
+  setExtensionHostProviderMock(mockRpc.invoke)
   const watchExpressions = [
     { expression: 'a + b', isEditing: false, value: null },
     { expression: 'x * y', isEditing: false, value: null },
@@ -51,7 +51,7 @@ test('evaluateWatchExpressions - one fails', async () => {
     },
   })
   RendererWorker.set(mockRpc)
-  ExtensionHost.set(mockRpc)
+  setExtensionHostProviderMock(mockRpc.invoke)
   const watchExpressions = [
     { expression: 'ok', isEditing: false, value: null },
     { expression: 'fail', isEditing: false, value: null },

--- a/packages/debug-worker/test/ExpandScopeChain.test.ts
+++ b/packages/debug-worker/test/ExpandScopeChain.test.ts
@@ -5,7 +5,7 @@ import type { RunAndDebugState } from '../src/parts/RunAndDebugState/RunAndDebug
 import type { ScopeChainItem } from '../src/parts/ScopeChainItem/ScopeChainItem.ts'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import { expandScopeChain } from '../src/parts/ExpandScopeChain/ExpandScopeChain.ts'
-import * as ExtensionHost from '../src/parts/ExtensionHost/ExtensionHost.ts'
+import { setExtensionHostProviderMock } from './MockExtensionHost.ts'
 
 test('expandScopeChain', async () => {
   const state: RunAndDebugState = createDefaultState()
@@ -67,7 +67,7 @@ test('expandScopeChain', async () => {
     },
   })
   RendererWorker.set(mockRpc)
-  ExtensionHost.set(mockRpc)
+  setExtensionHostProviderMock(mockRpc.invoke)
 
   const result = await expandScopeChain(state, expandedIds, scopeChain, element, index, debugId, 0)
 

--- a/packages/debug-worker/test/ExtensionHostDebug.test.ts
+++ b/packages/debug-worker/test/ExtensionHostDebug.test.ts
@@ -1,287 +1,77 @@
 import { expect, test } from '@jest/globals'
 import { MockRpc } from '@lvce-editor/rpc'
-import * as RpcRegistry from '@lvce-editor/rpc-registry'
-import { RpcId } from '@lvce-editor/rpc-registry'
-import { RendererWorker } from '@lvce-editor/rpc-registry'
 import * as ExtensionHost from '../src/parts/ExtensionHost/ExtensionHost.ts'
 import * as ExtensionHostDebug from '../src/parts/ExtensionHostDebug/ExtensionHostDebug.ts'
 
 const mockDebugId = 'test-debug-id'
+const mockEvent = `onDebug:${mockDebugId}`
+
+const setMockExtensionHost = (expectedMethod: string, expectedParams: readonly unknown[], result: unknown): void => {
+  const mockExtensionHost = MockRpc.create({
+    commandMap: {},
+    invoke: (method: string, ...params: readonly unknown[]) => {
+      expect([method, ...params]).toEqual(['Extensions.executeProvidersByEvent', mockEvent, expectedMethod, ...expectedParams])
+      return [result]
+    },
+  })
+  ExtensionHost.set(mockExtensionHost)
+}
 
 test('listProcesses', async () => {
   const mockProcesses = [{ id: 1 }, { id: 2 }]
-  const mockExtensionHost = MockRpc.create({
-    commandMap: {},
-    invoke: (method: string) => {
-      if (method === 'ExtensionHostDebug.listProcesses') {
-        return mockProcesses
-      }
-      throw new Error(`unexpected method ${method}`)
-    },
-  })
-  const mockRendererWorker = MockRpc.create({
-    commandMap: {},
-    invoke: (method: string) => {
-      if (method === 'ExtensionHostManagement.activateByEvent') {
-        return undefined
-      }
-      throw new Error(`unexpected method ${method}`)
-    },
-  })
-  ExtensionHost.set(mockExtensionHost)
-  RendererWorker.set(mockRendererWorker)
-  const result = await ExtensionHostDebug.listProcesses(mockDebugId)
-  expect(result).toEqual(mockProcesses)
+  setMockExtensionHost('ExtensionHostDebug.listProcesses', [mockDebugId], mockProcesses)
+  await expect(ExtensionHostDebug.listProcesses(mockDebugId)).resolves.toEqual(mockProcesses)
 })
 
-test('resume', async () => {
-  const mockExtensionHost = MockRpc.create({
-    commandMap: {},
-    invoke: (method: string) => {
-      if (method === 'ExtensionHostDebug.resume') {
-        return undefined
-      }
-      throw new Error(`unexpected method ${method}`)
-    },
-  })
-  const mockRendererWorker = MockRpc.create({
-    commandMap: {},
-    invoke: (method: string) => {
-      if (method === 'ExtensionHostManagement.activateByEvent') {
-        return undefined
-      }
-      throw new Error(`unexpected method ${method}`)
-    },
-  })
-  ExtensionHost.set(mockExtensionHost)
-  RendererWorker.set(mockRendererWorker)
-  await ExtensionHostDebug.resume(mockDebugId)
-})
-
-test('pause', async () => {
-  const mockResult = { status: 'paused' }
-  const mockExtensionHost = MockRpc.create({
-    commandMap: {},
-    invoke: (method: string) => {
-      if (method === 'ExtensionHostDebug.pause') {
-        return mockResult
-      }
-      throw new Error(`unexpected method ${method}`)
-    },
-  })
-  const mockRendererWorker = MockRpc.create({
-    commandMap: {},
-    invoke: (method: string) => {
-      if (method === 'ExtensionHostManagement.activateByEvent') {
-        return undefined
-      }
-      throw new Error(`unexpected method ${method}`)
-    },
-  })
-  ExtensionHost.set(mockExtensionHost)
-  RendererWorker.set(mockRendererWorker)
-  const result = await ExtensionHostDebug.pause(mockDebugId)
-  expect(result).toEqual(mockResult)
-})
-
-test('stepOver', async () => {
-  const mockResult = { status: 'stepped' }
-  const mockExtensionHost = MockRpc.create({
-    commandMap: {},
-    invoke: (method: string) => {
-      if (method === 'ExtensionHostDebug.stepOver') {
-        return mockResult
-      }
-      throw new Error(`unexpected method ${method}`)
-    },
-  })
-  const mockRendererWorker = MockRpc.create({
-    commandMap: {},
-    invoke: (method: string) => {
-      if (method === 'ExtensionHostManagement.activateByEvent') {
-        return undefined
-      }
-      throw new Error(`unexpected method ${method}`)
-    },
-  })
-  ExtensionHost.set(mockExtensionHost)
-  RendererWorker.set(mockRendererWorker)
-  const result = await ExtensionHostDebug.stepOver(mockDebugId)
-  expect(result).toEqual(mockResult)
-})
-
-test('stepInto', async () => {
-  const mockResult = { status: 'stepped' }
-  const mockExtensionHost = MockRpc.create({
-    commandMap: {},
-    invoke: (method: string) => {
-      if (method === 'ExtensionHostDebug.stepInto') {
-        return mockResult
-      }
-      throw new Error(`unexpected method ${method}`)
-    },
-  })
-  const mockRendererWorker = MockRpc.create({
-    commandMap: {},
-    invoke: (method: string) => {
-      if (method === 'ExtensionHostManagement.activateByEvent') {
-        return undefined
-      }
-      throw new Error(`unexpected method ${method}`)
-    },
-  })
-  ExtensionHost.set(mockExtensionHost)
-  RendererWorker.set(mockRendererWorker)
-  const result = await ExtensionHostDebug.stepInto(mockDebugId)
-  expect(result).toEqual(mockResult)
-})
-
-test('stepOut', async () => {
-  const mockResult = { status: 'stepped' }
-  const mockExtensionHost = MockRpc.create({
-    commandMap: {},
-    invoke: (method: string) => {
-      if (method === 'ExtensionHostDebug.stepOut') {
-        return mockResult
-      }
-      throw new Error(`unexpected method ${method}`)
-    },
-  })
-  const mockRendererWorker = MockRpc.create({
-    commandMap: {},
-    invoke: (method: string) => {
-      if (method === 'ExtensionHostManagement.activateByEvent') {
-        return undefined
-      }
-      throw new Error(`unexpected method ${method}`)
-    },
-  })
-  ExtensionHost.set(mockExtensionHost)
-  RendererWorker.set(mockRendererWorker)
-  const result = await ExtensionHostDebug.stepOut(mockDebugId)
-  expect(result).toEqual(mockResult)
+test.each([
+  ['resume', ExtensionHostDebug.resume, 'ExtensionHostDebug.resume'],
+  ['pause', ExtensionHostDebug.pause, 'ExtensionHostDebug.pause'],
+  ['stepOver', ExtensionHostDebug.stepOver, 'ExtensionHostDebug.stepOver'],
+  ['stepInto', ExtensionHostDebug.stepInto, 'ExtensionHostDebug.stepInto'],
+  ['stepOut', ExtensionHostDebug.stepOut, 'ExtensionHostDebug.stepOut'],
+  ['start', ExtensionHostDebug.start, 'ExtensionHostDebug.start'],
+] as const)('%s routes through executeProvidersByEvent', async (name, execute, expectedMethod) => {
+  const mockResult = { name }
+  setMockExtensionHost(expectedMethod, [mockDebugId], mockResult)
+  await expect(execute(mockDebugId)).resolves.toEqual(mockResult)
 })
 
 test('setPauseOnExceptions', async () => {
-  const mockValue = true
   const mockResult = { status: 'updated' }
-  const mockExtensionHost = MockRpc.create({
-    commandMap: {},
-    invoke: (method: string) => {
-      if (method === 'ExtensionHostDebug.setPauseOnExceptions') {
-        return mockResult
-      }
-      throw new Error(`unexpected method ${method}`)
-    },
-  })
-  const mockRendererWorker = MockRpc.create({
-    commandMap: {},
-    invoke: (method: string) => {
-      if (method === 'ExtensionHostManagement.activateByEvent') {
-        return undefined
-      }
-      throw new Error(`unexpected method ${method}`)
-    },
-  })
-  ExtensionHost.set(mockExtensionHost)
-  RendererWorker.set(mockRendererWorker)
-  const result = await ExtensionHostDebug.setPauseOnExceptions(mockDebugId, mockValue)
-  expect(result).toEqual(mockResult)
+  setMockExtensionHost('ExtensionHostDebug.setPauseOnExceptions', [mockDebugId, true], mockResult)
+  await expect(ExtensionHostDebug.setPauseOnExceptions(mockDebugId, true)).resolves.toEqual(mockResult)
 })
 
 test('getProperties', async () => {
-  const mockObjectId = 'obj-123'
   const mockProperties = [{ name: 'prop1', value: 'value1' }]
-  const mockExtensionHost = MockRpc.create({
-    commandMap: {},
-    invoke: (method: string) => {
-      if (method === 'ExtensionHostDebug.getProperties') {
-        return mockProperties
-      }
-      throw new Error(`unexpected method ${method}`)
-    },
-  })
-  const mockRendererWorker = MockRpc.create({
-    commandMap: {},
-    invoke: (method: string) => {
-      if (method === 'ExtensionHostManagement.activateByEvent') {
-        return undefined
-      }
-      throw new Error(`unexpected method ${method}`)
-    },
-  })
-  ExtensionHost.set(mockExtensionHost)
-  RendererWorker.set(mockRendererWorker)
-  const result = await ExtensionHostDebug.getProperties(mockDebugId, mockObjectId)
-  expect(result).toEqual(mockProperties)
+  setMockExtensionHost('ExtensionHostDebug.getProperties', [mockDebugId, 'obj-123'], mockProperties)
+  await expect(ExtensionHostDebug.getProperties(mockDebugId, 'obj-123')).resolves.toEqual(mockProperties)
 })
 
 test('evaluate', async () => {
-  const mockExpression = 'x + y'
-  const mockCallFrameId = 'frame-123'
   const mockResult = { result: 42 }
-  const mockExtensionHost = MockRpc.create({
-    commandMap: {},
-    invoke: (method: string) => {
-      if (method === 'ExtensionHostDebug.evaluate') {
-        return mockResult
-      }
-      throw new Error(`unexpected method ${method}`)
-    },
-  })
-  const mockRendererWorker = MockRpc.create({
-    commandMap: {},
-    invoke: (method: string) => {
-      if (method === 'ExtensionHostManagement.activateByEvent') {
-        return undefined
-      }
-      throw new Error(`unexpected method ${method}`)
-    },
-  })
-  ExtensionHost.set(mockExtensionHost)
-  RendererWorker.set(mockRendererWorker)
-  const result = await ExtensionHostDebug.evaluate(mockDebugId, mockExpression, mockCallFrameId)
-  expect(result).toEqual(mockResult)
+  setMockExtensionHost('ExtensionHostDebug.evaluate', [mockDebugId, 'x + y', 'frame-123'], mockResult)
+  await expect(ExtensionHostDebug.evaluate(mockDebugId, 'x + y', 'frame-123')).resolves.toEqual(mockResult)
 })
 
 test('getScriptSource', async () => {
-  const mockScriptId = 'script-123'
   const mockSource = 'function test() { return true; }'
-  const mockExtensionHost = MockRpc.create({
-    commandMap: {},
-    invoke: (method: string) => {
-      if (method === 'ExtensionHostDebug.getScriptSource') {
-        return mockSource
-      }
-      throw new Error(`unexpected method ${method}`)
-    },
-  })
-  const mockRendererWorker = MockRpc.create({
-    commandMap: {},
-    invoke: (method: string) => {
-      if (method === 'ExtensionHostManagement.activateByEvent') {
-        return undefined
-      }
-      throw new Error(`unexpected method ${method}`)
-    },
-  })
-  ExtensionHost.set(mockExtensionHost)
-  RendererWorker.set(mockRendererWorker)
-  const result = await ExtensionHostDebug.getScriptSource(mockDebugId, mockScriptId)
-  expect(result).toEqual(mockSource)
+  setMockExtensionHost('ExtensionHostDebug.getScriptSource', [mockDebugId, 'script-123'], mockSource)
+  await expect(ExtensionHostDebug.getScriptSource(mockDebugId, 'script-123')).resolves.toBe(mockSource)
 })
 
-test.skip('addWatchExpression', async () => {
-  const mockRpc = MockRpc.create({
-    commandMap: {},
-    invoke: (method: string) => {
-      if (method === 'ExtensionHostDebug.addWatchExpression') {
-        return {}
-      }
-      throw new Error(`unexpected method ${method}`)
-    },
-  })
-  RpcRegistry.set(RpcId.RendererWorker, mockRpc)
+test('addWatchExpression', async () => {
+  setMockExtensionHost('ExtensionHostDebug.addWatchExpression', [mockDebugId, 'x + y'], undefined)
+  await expect(ExtensionHostDebug.addWatchExpression(mockDebugId, 'x + y')).resolves.toBeUndefined()
+})
 
-  await ExtensionHostDebug.addWatchExpression('debug-1', 'x + y')
+test('reports a missing provider when no extension handles the event', async () => {
+  const mockExtensionHost = MockRpc.create({
+    commandMap: {},
+    invoke: () => [],
+  })
+  ExtensionHost.set(mockExtensionHost)
+  await expect(ExtensionHostDebug.start(mockDebugId)).rejects.toThrow(
+    'Failed to execute debug provider: no debug provider "test-debug-id" found',
+  )
 })

--- a/packages/debug-worker/test/GetInnerChildScopeChain.test.ts
+++ b/packages/debug-worker/test/GetInnerChildScopeChain.test.ts
@@ -3,6 +3,7 @@ import { MockRpc } from '@lvce-editor/rpc'
 import { RendererWorker } from '@lvce-editor/rpc-registry'
 import * as ExtensionHost from '../src/parts/ExtensionHost/ExtensionHost.ts'
 import { getInnerChildScopeChain } from '../src/parts/GetInnerChildScopeChain/GetInnerChildScopeChain.ts'
+import { createExtensionHostProviderMock } from './MockExtensionHost.ts'
 
 const mockRpc = MockRpc.create({
   commandMap: {},
@@ -33,7 +34,7 @@ const mockExtensionHost = MockRpc.create({
   },
 })
 
-ExtensionHost.set(mockExtensionHost)
+ExtensionHost.set(createExtensionHostProviderMock(mockExtensionHost.invoke))
 
 test('should return cached value if available', async () => {
   const cache = {

--- a/packages/debug-worker/test/GetPausedInfo2.test.ts
+++ b/packages/debug-worker/test/GetPausedInfo2.test.ts
@@ -4,6 +4,7 @@ import { RpcId } from '@lvce-editor/rpc-registry'
 import type { ParsedScriptMap } from '../src/parts/ParsedScriptMap/ParsedScriptMap.ts'
 import { getPausedInfo2 } from '../src/parts/GetPausedInfo2/GetPausedInfo2.ts'
 import * as RpcRegistry from '../src/parts/RpcRegistry/RpcRegistry.ts'
+import { createExtensionHostProviderMock } from './MockExtensionHost.ts'
 
 test.skip('getPausedInfo2', async () => {
   const mockDebugId = 'test-debug-id'
@@ -71,7 +72,7 @@ test.skip('getPausedInfo2', async () => {
       throw new Error(`unexpected method ${method}`)
     },
   })
-  RpcRegistry.set(RpcId.ExtensionHostWorker, mockRpc)
+  RpcRegistry.set(RpcId.ExtensionHostWorker, createExtensionHostProviderMock(mockRpc.invoke))
 
   // Register mock RPC for RendererWorker
   const mockRendererWorkerRpc = MockRpc.create({

--- a/packages/debug-worker/test/HandleClickCheckBox.test.ts
+++ b/packages/debug-worker/test/HandleClickCheckBox.test.ts
@@ -6,6 +6,7 @@ import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaul
 import * as ExtensionHost from '../src/parts/ExtensionHost/ExtensionHost.ts'
 import { handleClickCheckBox } from '../src/parts/HandleClickCheckBox/HandleClickCheckBox.ts'
 import * as InputName from '../src/parts/InputName/InputName.ts'
+import { createExtensionHostProviderMock } from './MockExtensionHost.ts'
 
 test('handleClickCheckBox with pause-on-exceptions', async () => {
   const mockRendererWorker = MockRpc.create({
@@ -22,7 +23,7 @@ test('handleClickCheckBox with pause-on-exceptions', async () => {
     commandMap: {},
     invoke: () => undefined,
   })
-  ExtensionHost.set(mockExtensionHost)
+  ExtensionHost.set(createExtensionHostProviderMock(mockExtensionHost.invoke))
   const state: RunAndDebugState = createDefaultState()
   const result = await handleClickCheckBox(state, InputName.PauseOnExceptions)
   expect(result).toBeDefined()
@@ -43,7 +44,7 @@ test('handleClickCheckBox with pause-on-uncaught-exceptions', async () => {
     commandMap: {},
     invoke: () => undefined,
   })
-  ExtensionHost.set(mockExtensionHost)
+  ExtensionHost.set(createExtensionHostProviderMock(mockExtensionHost.invoke))
   const state: RunAndDebugState = createDefaultState()
   const result = await handleClickCheckBox(state, InputName.PauseOnUncaughtExceptions)
   expect(result).toBeDefined()
@@ -64,7 +65,7 @@ test('handleClickCheckBox with invalid name throws error', async () => {
     commandMap: {},
     invoke: () => undefined,
   })
-  ExtensionHost.set(mockExtensionHost)
+  ExtensionHost.set(createExtensionHostProviderMock(mockExtensionHost.invoke))
   const state: RunAndDebugState = createDefaultState()
   expect(() => handleClickCheckBox(state, 'invalid-name')).toThrow('unknown input name')
 })

--- a/packages/debug-worker/test/HandleClickDebugButton.test.ts
+++ b/packages/debug-worker/test/HandleClickDebugButton.test.ts
@@ -3,9 +3,9 @@ import { MockRpc } from '@lvce-editor/rpc'
 import { RendererWorker } from '@lvce-editor/rpc-registry'
 import type { RunAndDebugState } from '../src/parts/RunAndDebugState/RunAndDebugState.ts'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
-import * as ExtensionHost from '../src/parts/ExtensionHost/ExtensionHost.ts'
 import { handleClickDebugButton } from '../src/parts/HandleClickDebugButton/HandleClickDebugButton.ts'
 import * as InputName from '../src/parts/InputName/InputName.ts'
+import { setExtensionHostProviderMock } from './MockExtensionHost.ts'
 
 const called: string[] = []
 const mockRpc = MockRpc.create({
@@ -19,7 +19,7 @@ const mockRpc = MockRpc.create({
 beforeEach(() => {
   called.length = 0
   RendererWorker.set(mockRpc)
-  ExtensionHost.set(mockRpc)
+  setExtensionHostProviderMock(mockRpc.invoke)
 })
 
 test('pause button calls ExtensionHostDebug.pause', async () => {

--- a/packages/debug-worker/test/HandleClickPauseOnExceptions.test.ts
+++ b/packages/debug-worker/test/HandleClickPauseOnExceptions.test.ts
@@ -6,6 +6,7 @@ import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaul
 import * as ExceptionBreakPoints from '../src/parts/ExceptionBreakPoints/ExceptionBreakPoints.ts'
 import * as ExtensionHost from '../src/parts/ExtensionHost/ExtensionHost.ts'
 import { handleClickPauseOnExceptions } from '../src/parts/HandleClickPauseOnExceptions/HandleClickPauseOnExceptions.ts'
+import { createExtensionHostProviderMock } from './MockExtensionHost.ts'
 
 test('handleClickPauseOnExceptions toggles from None to All', async () => {
   const mockRendererWorker = MockRpc.create({
@@ -28,7 +29,7 @@ test('handleClickPauseOnExceptions toggles from None to All', async () => {
       return
     },
   })
-  ExtensionHost.set(mockExtensionHost)
+  ExtensionHost.set(createExtensionHostProviderMock(mockExtensionHost.invoke))
 
   const state: RunAndDebugState = createDefaultState()
   const newState = await handleClickPauseOnExceptions(state)
@@ -56,7 +57,7 @@ test('handleClickPauseOnExceptions toggles from Uncaught to All', async () => {
       return
     },
   })
-  ExtensionHost.set(mockExtensionHost)
+  ExtensionHost.set(createExtensionHostProviderMock(mockExtensionHost.invoke))
 
   const state = {
     ...createDefaultState(),
@@ -87,7 +88,7 @@ test('handleClickPauseOnExceptions toggles from All to None', async () => {
       return
     },
   })
-  ExtensionHost.set(mockExtensionHost)
+  ExtensionHost.set(createExtensionHostProviderMock(mockExtensionHost.invoke))
   const state = {
     ...createDefaultState(),
     exceptionBreakPoints: ExceptionBreakPoints.All,

--- a/packages/debug-worker/test/HandleClickPauseOnUncaughtExceptions.test.ts
+++ b/packages/debug-worker/test/HandleClickPauseOnUncaughtExceptions.test.ts
@@ -6,6 +6,7 @@ import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaul
 import * as ExceptionBreakPoints from '../src/parts/ExceptionBreakPoints/ExceptionBreakPoints.ts'
 import * as ExtensionHost from '../src/parts/ExtensionHost/ExtensionHost.ts'
 import { handleClickPauseOnUncaughtExceptions } from '../src/parts/HandleClickPauseOnUncaughtExceptions/HandleClickPauseOnUncaughtExceptions.ts'
+import { createExtensionHostProviderMock } from './MockExtensionHost.ts'
 
 const setupRendererAndExtensionHost = async (): Promise<void> => {
   const mockRendererWorker = MockRpc.create({
@@ -28,7 +29,7 @@ const setupRendererAndExtensionHost = async (): Promise<void> => {
       throw new Error(`unexpected method ${method}`)
     },
   })
-  ExtensionHost.set(mockExtensionHost)
+  ExtensionHost.set(createExtensionHostProviderMock(mockExtensionHost.invoke))
 }
 
 test('handleClickPauseOnUncaughtExceptions - from None to Uncaught', async () => {

--- a/packages/debug-worker/test/HandlePaused.test.ts
+++ b/packages/debug-worker/test/HandlePaused.test.ts
@@ -4,8 +4,8 @@ import { RendererWorker } from '@lvce-editor/rpc-registry'
 import type { RunAndDebugState } from '../src/parts/RunAndDebugState/RunAndDebugState.ts'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import * as DebugState from '../src/parts/DebugState/DebugState.ts'
-import * as ExtensionHost from '../src/parts/ExtensionHost/ExtensionHost.ts'
 import { handlePaused, togglePause } from '../src/parts/HandlePaused/HandlePaused.ts'
+import { setExtensionHostProviderMock } from './MockExtensionHost.ts'
 
 const setupMocks = async (invokeImpl: (method: string) => Promise<any>): Promise<void> => {
   const mockRpc = MockRpc.create({
@@ -13,7 +13,7 @@ const setupMocks = async (invokeImpl: (method: string) => Promise<any>): Promise
     invoke: invokeImpl,
   })
   RendererWorker.set(mockRpc)
-  ExtensionHost.set(mockRpc)
+  setExtensionHostProviderMock(mockRpc.invoke)
 }
 
 test.skip('handlePaused updates state correctly', async () => {

--- a/packages/debug-worker/test/HandleSpace.test.ts
+++ b/packages/debug-worker/test/HandleSpace.test.ts
@@ -7,6 +7,7 @@ import * as DebugRowType from '../src/parts/DebugRowType/DebugRowType.ts'
 import * as ExtensionHost from '../src/parts/ExtensionHost/ExtensionHost.ts'
 import { handleSpace } from '../src/parts/HandleSpace/HandleSpace.ts'
 import * as InputName from '../src/parts/InputName/InputName.ts'
+import { createExtensionHostProviderMock } from './MockExtensionHost.ts'
 
 test('handleSpace does nothing when no row is selected', async () => {
   const state: RunAndDebugState = createDefaultState()
@@ -47,7 +48,7 @@ test('handleSpace toggles checkbox rows', async () => {
     commandMap: {},
     invoke: () => undefined,
   })
-  ExtensionHost.set(mockExtensionHost)
+  ExtensionHost.set(createExtensionHostProviderMock(mockExtensionHost.invoke))
 
   const checkboxRow = {
     description: '',

--- a/packages/debug-worker/test/LoadContentLater.test.ts
+++ b/packages/debug-worker/test/LoadContentLater.test.ts
@@ -1,6 +1,5 @@
 import { expect, jest, test } from '@jest/globals'
 import { MockRpc } from '@lvce-editor/rpc'
-import { RendererWorker } from '@lvce-editor/rpc-registry'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import * as DebugRowType from '../src/parts/DebugRowType/DebugRowType.ts'
 import * as DebugState from '../src/parts/DebugState/DebugState.ts'
@@ -9,28 +8,18 @@ import * as ExtensionHost from '../src/parts/ExtensionHost/ExtensionHost.ts'
 import { loadContentLater } from '../src/parts/LoadContentLater/LoadContentLater.ts'
 
 test('loadContentLater shows missing debug provider message', async () => {
-  const rendererWorkerRpc = MockRpc.create({
-    commandMap: {},
-    invoke: (method: string) => {
-      if (method === 'ExtensionHostManagement.activateByEvent') {
-        return undefined
-      }
-      throw new Error(`unexpected method ${method}`)
-    },
-  })
   const extensionHostRpc = MockRpc.create({
     commandMap: {},
     invoke: (method: string) => {
-      if (method === 'ExtensionHostDebug.start') {
-        throw new Error('Failed to execute debug provider: no debug provider "node-debug" found')
+      if (method === 'Extensions.executeProvidersByEvent') {
+        return []
       }
       throw new Error(`unexpected method ${method}`)
     },
   })
-  RendererWorker.set(rendererWorkerRpc)
   ExtensionHost.set(extensionHostRpc)
 
-  const result = await loadContentLater(createDefaultState(1))
+  const result = await loadContentLater({ ...createDefaultState(1), debugId: 'node-debug' })
 
   expect(result.debugState).toBe(DebugState.MissingProvider)
   expect(result.debugProviderMessage).toBe(DebugStrings.noDebugProviderFound('node-debug'))
@@ -53,15 +42,6 @@ test('loadContentLater shows missing debug provider message', async () => {
 })
 
 test('loadContentLater rethrows other start errors', async () => {
-  const rendererWorkerRpc = MockRpc.create({
-    commandMap: {},
-    invoke: (method: string) => {
-      if (method === 'ExtensionHostManagement.activateByEvent') {
-        return undefined
-      }
-      throw new Error(`unexpected method ${method}`)
-    },
-  })
   const error = new Error('startup failed')
   const extensionHostRpc = MockRpc.create({
     commandMap: {},
@@ -69,7 +49,6 @@ test('loadContentLater rethrows other start errors', async () => {
       throw error
     }),
   })
-  RendererWorker.set(rendererWorkerRpc)
   ExtensionHost.set(extensionHostRpc)
 
   await expect(loadContentLater(createDefaultState(1))).rejects.toBe(error)

--- a/packages/debug-worker/test/MockExtensionHost.ts
+++ b/packages/debug-worker/test/MockExtensionHost.ts
@@ -1,0 +1,22 @@
+import { MockRpc } from '@lvce-editor/rpc'
+import * as ExtensionHost from '../src/parts/ExtensionHost/ExtensionHost.ts'
+
+type Invoke = (method: string, ...params: readonly any[]) => any
+
+export const createExtensionHostProviderMock = (invokeProvider: Invoke): ReturnType<typeof MockRpc.create> => {
+  return MockRpc.create({
+    commandMap: {},
+    invoke: async (method: string, ...params: readonly any[]) => {
+      if (method !== 'Extensions.executeProvidersByEvent') {
+        throw new Error(`unexpected method ${method}`)
+      }
+      const [, providerMethod, ...providerParams] = params
+      const result = await invokeProvider(providerMethod, ...providerParams)
+      return [result]
+    },
+  })
+}
+
+export const setExtensionHostProviderMock = (invokeProvider: Invoke): void => {
+  ExtensionHost.set(createExtensionHostProviderMock(invokeProvider))
+}

--- a/packages/debug-worker/test/ReadFile.test.ts
+++ b/packages/debug-worker/test/ReadFile.test.ts
@@ -5,6 +5,7 @@ import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaul
 import * as ReadFile from '../src/parts/ReadFile/ReadFile.js'
 import { readFile } from '../src/parts/ReadFile/ReadFile.ts'
 import * as RunAndDebugStates from '../src/parts/RunAndDebugStates/RunAndDebugStates.ts'
+import { createExtensionHostProviderMock } from './MockExtensionHost.ts'
 
 test('should correctly parse URI and return empty string for invalid input', async () => {
   const result = await ReadFile.readFile('invalid-uri')
@@ -42,7 +43,7 @@ test('readFile', async () => {
       throw new Error(`unexpected method ${method}`)
     },
   })
-  ExtensionHost.set(mockExtensionHostRpc)
+  ExtensionHost.set(createExtensionHostProviderMock(mockExtensionHostRpc.invoke))
 
   const mockRendererWorkerRpc = MockRpc.create({
     commandMap: {},
@@ -79,7 +80,7 @@ test('readFile - no instance found', async () => {
       throw new Error(`unexpected method ${method}`)
     },
   })
-  ExtensionHost.set(mockExtensionHostRpc)
+  ExtensionHost.set(createExtensionHostProviderMock(mockExtensionHostRpc.invoke))
 
   const mockRendererWorkerRpc = MockRpc.create({
     commandMap: {},

--- a/packages/debug-worker/test/RefreshWatchExpression.test.ts
+++ b/packages/debug-worker/test/RefreshWatchExpression.test.ts
@@ -4,8 +4,8 @@ import { RendererWorker } from '@lvce-editor/rpc-registry'
 import type { RunAndDebugState } from '../src/parts/RunAndDebugState/RunAndDebugState.ts'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import * as DebugState from '../src/parts/DebugState/DebugState.ts'
-import * as ExtensionHost from '../src/parts/ExtensionHost/ExtensionHost.ts'
 import { refreshWatchExpression } from '../src/parts/RefreshWatchExpression/RefreshWatchExpression.ts'
+import { setExtensionHostProviderMock } from './MockExtensionHost.ts'
 
 test('refreshWatchExpression - when not paused, returns same state', async () => {
   const state: RunAndDebugState = {
@@ -38,7 +38,7 @@ test('refreshWatchExpression - when paused, evaluates all expressions', async ()
     },
   })
   RendererWorker.set(mockRpc)
-  ExtensionHost.set(mockRpc)
+  setExtensionHostProviderMock(mockRpc.invoke)
 
   const state: RunAndDebugState = {
     ...createDefaultState(),

--- a/packages/debug-worker/test/SetPauseOnExceptions.test.ts
+++ b/packages/debug-worker/test/SetPauseOnExceptions.test.ts
@@ -5,6 +5,7 @@ import type { RunAndDebugState } from '../src/parts/RunAndDebugState/RunAndDebug
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import * as RpcRegistry from '../src/parts/RpcRegistry/RpcRegistry.ts'
 import { setPauseOnExceptions } from '../src/parts/SetPauseOnExceptions/SetPauseOnExceptions.ts'
+import { createExtensionHostProviderMock } from './MockExtensionHost.ts'
 
 const setupRendererWorker = async (): Promise<void> => {
   const mockRendererWorkerRpc = MockRpc.create({
@@ -25,7 +26,7 @@ test('setPauseOnExceptions - success', async () => {
       throw new Error(`unexpected method ${method}`)
     },
   })
-  RpcRegistry.set(RpcId.ExtensionHostWorker, mockRpc)
+  RpcRegistry.set(RpcId.ExtensionHostWorker, createExtensionHostProviderMock(mockRpc.invoke))
 
   const state: RunAndDebugState = createDefaultState()
   const value = true
@@ -50,7 +51,7 @@ test('setPauseOnExceptions - error', async () => {
       throw new Error(`unexpected method ${method}`)
     },
   })
-  RpcRegistry.set(RpcId.ExtensionHostWorker, mockRpc)
+  RpcRegistry.set(RpcId.ExtensionHostWorker, createExtensionHostProviderMock(mockRpc.invoke))
 
   const state: RunAndDebugState = createDefaultState()
   const value = true


### PR DESCRIPTION
## Summary
- route debug operations through the extension-management provider dispatcher
- preserve first-provider semantics and report missing debug providers
- update debug command tests to cover the real RPC contract

## Testing
- npm test --workspace=packages/debug-worker -- --runInBand
- npm run type-check
- npm run lint
- npm run build